### PR TITLE
Require Craft 3 RC1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,5 +37,8 @@
         "components": {
             "defaultService": "selvinortiz\\patrol\\services\\PatrolService"
         }
+    },
+    "require": {
+        "craftcms/cms": "^3.0.0-RC1"
     }
 }


### PR DESCRIPTION
The Plugin Store is eventually going to require that plugins define their Craft CMS compatibility, via the `require` property in composer.json.