### PR TITLE
Ensure there is a trailing slash when using serverName

### DIFF
--- a/src/services/PatrolService.php
+++ b/src/services/PatrolService.php
@@ -182,6 +182,8 @@ class PatrolService extends Component
         if (empty($baseUrl) || $baseUrl == '/')
         {
             $baseUrl = Craft::$app->request->serverName;
+            // Ensure trailing slash
+            $baseUrl = '/'.ltrim($baseUrl, '/');
         }
 
         $url = sprintf('%s%s', $baseUrl, ltrim(Craft::$app->request->getUrl(), '/')); // http://domain.com/page?query=something


### PR DESCRIPTION
Hello!

I'm having the same problem with forcing SSL as described in #9 

I've looked further into this and found it's when sslRoutingBaseUrl is blank or `/` the baseUrl is then set to the serverName which omits the trailing slash, so I've added a check to fix this which is now working for me.

Happy to make any changes if you wish.