### PR TITLE
Fix forceSsl exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ return [
         'primaryDomain' => null,
         'redirectStatusCode' => 302,
 
+        'sslRoutingBaseUrl' => "https://mysecuredwebsite.com",
         'sslRoutingEnabled' => true,
         'sslRoutingRestrictedUrls' => ['/'],
 
@@ -86,6 +87,10 @@ Redirect status code to use when...
 1. redirecting to and from SSL restricted URLs
 2. redirecting to primary domain, if one is defined.
 
+#### `$sslRoutingBaseUrl`
+> Defaults to `Craft::$app->request->hostInfo`
+
+Tells Patrol what base URL to use when redirecting to SSL
 
 #### `$sslRoutingEnabled`
 > Defaults to `false`

--- a/src/services/PatrolService.php
+++ b/src/services/PatrolService.php
@@ -181,7 +181,7 @@ class PatrolService extends Component
 
         if (empty($baseUrl) || $baseUrl == '/')
         {
-            $baseUrl = Craft::$app->request->serverName;
+            $baseUrl = Craft::$app->request->hostInfo;
             // Ensure trailing slash
             $baseUrl = '/'.ltrim($baseUrl, '/');
         }


### PR DESCRIPTION
This ensures Patrol starts with a `baseUrl` containing the schema (and includes a port if used) before trimming/replacing `http:` and avoids it throwing a `FILTER_VALIDATE_URL` exception. I also added the available override setting to the readme.